### PR TITLE
Make buildable with ghc 9.8

### DIFF
--- a/paths.cabal
+++ b/paths.cabal
@@ -74,13 +74,13 @@ library
     other-extensions:  TemplateHaskell
 
 
-  build-depends:       base             >=4.5    && <4.18
+  build-depends:       base             >=4.5    && <4.20
                      , bytestring       >=0.9.2  && <0.12
-                     , deepseq          >=1.3    && <1.5
+                     , deepseq          >=1.3    && <1.6
                      , directory        >=1.1    && <1.4
                      , filepath         >=1.3    && <1.5
-                     , template-haskell >=2.7    && <2.20
-                     , text             >=0.11   && <1.3  || >=2.0 && <2.1
+                     , template-haskell >=2.7    && <2.22
+                     , text             >=0.11   && <1.3  || >=2.0 && <2.2
                      , time             >=1.4    && <1.13
 
   if !impl(ghc >= 8.0)

--- a/src/System/Path/Internal.hs
+++ b/src/System/Path/Internal.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DefaultSignatures         #-}
 {-# LANGUAGE DeriveDataTypeable        #-}
 {-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE Safe                      #-}
+{-# LANGUAGE Trustworthy               #-}
 {-# LANGUAGE ScopedTypeVariables       #-}
 
 module System.Path.Internal (

--- a/src/System/Path/Internal/Compat.hs
+++ b/src/System/Path/Internal/Compat.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE CPP  #-}
-{-# LANGUAGE Safe #-}
+{-# LANGUAGE Trustworthy #-}
 
 {-# OPTIONS_GHC -fno-warn-unused-imports #-}
 

--- a/src/System/Path/QQ.hs
+++ b/src/System/Path/QQ.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE CPP                   #-}
 
-#if __GLASGOW_HASKELL__ >= 802
-{-# LANGUAGE Safe                  #-}
+#if (__GLASGOW_HASKELL__ >= 802) && ( __GLASGOW_HASKELL__ >= 806)
+{-# LANGUAGE Safe           #-}
 #else
 {-# LANGUAGE Trustworthy           #-}
 #endif


### PR DESCRIPTION
I'm very uncertain about why we need the Trustworthy commit. GHC is complaining for no reason I can discern. The directory module doesn't have an explicit declaration, so maybe one of its imports changed its inferred status?

```
src/System/Path/Internal.hs:74:1: error: [GHC-44360]                                                                                              
    System.Directory: Can't be safely imported!                                                                                                   
    The module itself isn't safe.                                                                                                                 
   |                                                                                                                                              
74 | import qualified System.Directory            as Dir                                                                                          
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                          
```